### PR TITLE
chore: add build.yml + sonar-project.properties for SonarQube

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=ReTiCh-Corp_ReTiCh-User
+sonar.organization=retich-corp
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=ReTiCh-User
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
What's been done here:

- Added SonarQube config file for project analysis on main branch and pull request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds CI/static analysis configuration only; the main risk is CI failures or noisy results if `SONAR_TOKEN`/Sonar settings are misconfigured.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/build.yml`) that runs a SonarQube scan on pushes to `main` and on PR events, using a full git history checkout.
> 
> Introduces `sonar-project.properties` with the project key and organization to configure Sonar analysis for the repository.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4992f87cc86d45b3b778177e715e4c5b7ad063e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->