### PR TITLE
feat: add database schema migrations

### DIFF
--- a/migrations/000001_init_schema.down.sql
+++ b/migrations/000001_init_schema.down.sql
@@ -1,0 +1,14 @@
+-- Rollback User Service Schema
+
+DROP TRIGGER IF EXISTS update_user_settings_updated_at ON user_settings;
+DROP TRIGGER IF EXISTS update_profiles_updated_at ON profiles;
+DROP FUNCTION IF EXISTS update_updated_at_column();
+
+DROP TABLE IF EXISTS blocked_users;
+DROP TABLE IF EXISTS friend_requests;
+DROP TABLE IF EXISTS contacts;
+DROP TABLE IF EXISTS user_settings;
+DROP TABLE IF EXISTS profiles;
+
+DROP TYPE IF EXISTS friend_request_status;
+DROP TYPE IF EXISTS user_status;

--- a/migrations/000001_init_schema.up.sql
+++ b/migrations/000001_init_schema.up.sql
@@ -1,0 +1,111 @@
+-- User Service Schema
+-- Handles user profiles, settings, and relationships
+
+-- Enable required extensions
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- User status enum
+CREATE TYPE user_status AS ENUM ('online', 'offline', 'away', 'busy', 'invisible');
+
+-- User profiles
+CREATE TABLE profiles (
+    id UUID PRIMARY KEY, -- Same as auth.users.id
+    username VARCHAR(50) NOT NULL UNIQUE,
+    display_name VARCHAR(100),
+    avatar_url VARCHAR(500),
+    bio TEXT,
+    status user_status DEFAULT 'offline',
+    custom_status VARCHAR(100),
+    last_seen_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- User settings/preferences
+CREATE TABLE user_settings (
+    user_id UUID PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+    theme VARCHAR(20) DEFAULT 'system', -- 'light', 'dark', 'system'
+    language VARCHAR(10) DEFAULT 'fr',
+    timezone VARCHAR(50) DEFAULT 'Europe/Paris',
+    notifications_enabled BOOLEAN DEFAULT TRUE,
+    sound_enabled BOOLEAN DEFAULT TRUE,
+    desktop_notifications BOOLEAN DEFAULT TRUE,
+    email_notifications BOOLEAN DEFAULT TRUE,
+    show_online_status BOOLEAN DEFAULT TRUE,
+    show_read_receipts BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- User contacts/friends
+CREATE TABLE contacts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    contact_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    nickname VARCHAR(100),
+    is_favorite BOOLEAN DEFAULT FALSE,
+    is_blocked BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT unique_contact UNIQUE (user_id, contact_id),
+    CONSTRAINT no_self_contact CHECK (user_id != contact_id)
+);
+
+-- Friend requests
+CREATE TYPE friend_request_status AS ENUM ('pending', 'accepted', 'rejected', 'cancelled');
+
+CREATE TABLE friend_requests (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    sender_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    receiver_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    status friend_request_status DEFAULT 'pending',
+    message VARCHAR(500),
+    responded_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT unique_friend_request UNIQUE (sender_id, receiver_id),
+    CONSTRAINT no_self_request CHECK (sender_id != receiver_id)
+);
+
+-- Blocked users
+CREATE TABLE blocked_users (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    blocked_user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    reason VARCHAR(500),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT unique_block UNIQUE (user_id, blocked_user_id),
+    CONSTRAINT no_self_block CHECK (user_id != blocked_user_id)
+);
+
+-- Indexes for performance
+CREATE INDEX idx_profiles_username ON profiles(username);
+CREATE INDEX idx_profiles_status ON profiles(status) WHERE status != 'offline';
+CREATE INDEX idx_profiles_last_seen ON profiles(last_seen_at);
+CREATE INDEX idx_contacts_user_id ON contacts(user_id);
+CREATE INDEX idx_contacts_contact_id ON contacts(contact_id);
+CREATE INDEX idx_contacts_favorites ON contacts(user_id) WHERE is_favorite = TRUE;
+CREATE INDEX idx_friend_requests_receiver ON friend_requests(receiver_id) WHERE status = 'pending';
+CREATE INDEX idx_friend_requests_sender ON friend_requests(sender_id);
+CREATE INDEX idx_blocked_users_user_id ON blocked_users(user_id);
+
+-- Updated_at trigger function
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Apply triggers
+CREATE TRIGGER update_profiles_updated_at
+    BEFORE UPDATE ON profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_user_settings_updated_at
+    BEFORE UPDATE ON user_settings
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- Add `profiles` table for user information
- Add `user_settings` table for preferences
- Add `contacts` table for friend relationships
- Add `friend_requests` table
- Add `blocked_users` table
- Add enums: `user_status`, `friend_request_status`

## Schema
```
profiles
├── id (UUID, PK - same as auth.users.id)
├── username (UNIQUE)
├── display_name
├── avatar_url
├── bio
├── status (online/offline/away/busy/invisible)
└── last_seen_at

user_settings
├── user_id (PK, FK → profiles)
├── theme
├── language
├── notifications_enabled
└── ...

contacts
├── user_id (FK → profiles)
├── contact_id (FK → profiles)
├── nickname
├── is_favorite
└── is_blocked

friend_requests
├── sender_id (FK → profiles)
├── receiver_id (FK → profiles)
├── status (pending/accepted/rejected/cancelled)
└── message
```

## Test plan
- [ ] Run migrations: `make migrate-user`
- [ ] Verify tables created in `retich_users` database
- [ ] Test rollback: `make rollback-user`