### PR TITLE
fix: auto-provision user and profile on first authenticated request

### DIFF
--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/retich-corp/user/internal/model"
@@ -33,6 +34,7 @@ var allowedMIMETypes = map[string]string{
 // userRepository définit les opérations en base attendues par le handler.
 // Utiliser une interface permet d'injecter un mock dans les tests sans base de données réelle.
 type userRepository interface {
+	EnsureUserAndProfile(id, email string) error
 	GetByID(id string) (*model.Profile, error)
 	UpdateByID(id string, req *model.UpdateProfileRequest) (*model.Profile, error)
 	UpdateAvatarURL(id, avatarURL string) (*model.Profile, error)
@@ -132,6 +134,12 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 // Répond 200 + profil complet mis à jour, ou 400 / 404 / 500 selon le cas.
 func (h *UserHandler) UpdateAvatar(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
+	email := r.Header.Get("X-User-Email")
+
+	if err := h.repo.EnsureUserAndProfile(id, email); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
 
 	// Limite le body à maxUploadSize pour rejeter les gros fichiers avant même de les lire.
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
@@ -206,6 +214,12 @@ func (h *UserHandler) UpdateAvatar(w http.ResponseWriter, r *http.Request) {
 // Remplace tous les champs modifiables du profil (remplacement complet).
 func (h *UserHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
+	email := r.Header.Get("X-User-Email")
+
+	if err := h.repo.EnsureUserAndProfile(id, email); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
 
 	var req model.UpdateProfileRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -216,6 +230,14 @@ func (h *UserHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	if req.Username == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "username is required"})
 		return
+	}
+
+	// Auto-générer display_name si non fourni et first/last name présents.
+	if req.DisplayName == nil && req.FirstName != nil && req.LastName != nil {
+		dn := strings.TrimSpace(*req.FirstName + " " + *req.LastName)
+		if dn != "" {
+			req.DisplayName = &dn
+		}
 	}
 
 	profile, err := h.repo.UpdateByID(id, &req)
@@ -317,6 +339,11 @@ func (h *UserHandler) CheckUsername(w http.ResponseWriter, r *http.Request) {
 // Retourne le profil complet de l'utilisateur ou 404 s'il n'existe pas.
 func (h *UserHandler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
+	email := r.Header.Get("X-User-Email")
+
+	if email != "" {
+		_ = h.repo.EnsureUserAndProfile(id, email)
+	}
 
 	profile, err := h.repo.GetByID(id)
 	if err != nil {

--- a/internal/handler/user_handler_test.go
+++ b/internal/handler/user_handler_test.go
@@ -25,6 +25,10 @@ type mockRepo struct {
 	usernameErr     error
 }
 
+func (m *mockRepo) EnsureUserAndProfile(_, _ string) error {
+	return nil
+}
+
 func (m *mockRepo) GetByID(_ string) (*model.Profile, error) {
 	return m.profile, m.err
 }

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -17,15 +17,38 @@ func NewUserRepository(db *sql.DB) *UserRepository {
 	return &UserRepository{db: db}
 }
 
-// Create insère un nouvel utilisateur dans la table users.
+// EnsureUserAndProfile garantit qu'une ligne existe dans users ET profiles
+// pour l'ID donné. Idempotent grâce à ON CONFLICT DO NOTHING.
+func (r *UserRepository) EnsureUserAndProfile(id, email string) error {
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	_, err = tx.Exec(`INSERT INTO users (id, email) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`, id, email)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(`INSERT INTO profiles (id) VALUES ($1) ON CONFLICT (id) DO NOTHING`, id)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// Create insère un nouvel utilisateur dans les tables users et profiles.
 func (r *UserRepository) Create(id, email string) (*model.User, error) {
+	if err := r.EnsureUserAndProfile(id, email); err != nil {
+		return nil, err
+	}
+
 	user := &model.User{}
 	query := `
-		INSERT INTO users (id, email)
-		VALUES ($1, $2)
-		RETURNING id, email, onboarding_completed, created_at, updated_at`
+		SELECT id, email, onboarding_completed, created_at, updated_at
+		FROM users WHERE id = $1`
 
-	err := r.db.QueryRow(query, id, email).Scan(
+	err := r.db.QueryRow(query, id).Scan(
 		&user.ID,
 		&user.Email,
 		&user.OnboardingCompleted,

--- a/internal/repository/user_repository_test.go
+++ b/internal/repository/user_repository_test.go
@@ -60,8 +60,16 @@ func TestCreate_Success(t *testing.T) {
 	db, mock := newMock(t)
 	defer db.Close()
 
-	mock.ExpectQuery("INSERT INTO users").
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO users").
 		WithArgs("new-uuid", "new@example.com").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO profiles").
+		WithArgs("new-uuid").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	mock.ExpectQuery("SELECT .+ FROM users WHERE id").
+		WithArgs("new-uuid").
 		WillReturnRows(sampleUserRow())
 
 	repo := NewUserRepository(db)
@@ -82,15 +90,38 @@ func TestCreate_DBError(t *testing.T) {
 	db, mock := newMock(t)
 	defer db.Close()
 
-	mock.ExpectQuery("INSERT INTO users").
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO users").
 		WithArgs("new-uuid", "new@example.com").
 		WillReturnError(errors.New("duplicate key"))
+	mock.ExpectRollback()
 
 	repo := NewUserRepository(db)
 	_, err := repo.Create("new-uuid", "new@example.com")
 
 	if err == nil {
 		t.Error("expected an error, got nil")
+	}
+}
+
+func TestEnsureUserAndProfile_Success(t *testing.T) {
+	db, mock := newMock(t)
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO users").
+		WithArgs("uuid-1", "test@example.com").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO profiles").
+		WithArgs("uuid-1").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	repo := NewUserRepository(db)
+	err := repo.EnsureUserAndProfile("uuid-1", "test@example.com")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Add EnsureUserAndProfile to create users/profiles rows on the fly when they don't exist yet, fixing 500 errors on PUT /users/me after auth. Also auto-generate display_name from first_name + last_name.