### PR TITLE
feat(avatar): add AvatarStorage interface with Azure Blob and local b…

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/retich-corp/user/internal/handler"
 	"github.com/retich-corp/user/internal/repository"
+	"github.com/retich-corp/user/internal/storage"
 
 	_ "github.com/lib/pq"
 )
@@ -39,22 +40,8 @@ func main() {
 		log.Fatal("DATABASE_URL environment variable is required")
 	}
 
-	// UPLOADS_DIR : dossier où les avatars sont stockés sur disque.
-	uploadsDir := os.Getenv("UPLOADS_DIR")
-	if uploadsDir == "" {
-		uploadsDir = "./uploads"
-	}
-
-	// BASE_URL : URL publique du service, utilisée pour construire les liens d'avatars.
-	baseURL := os.Getenv("BASE_URL")
-	if baseURL == "" {
-		baseURL = "http://localhost:" + port
-	}
-
-	// Crée le dossier d'uploads s'il n'existe pas encore.
-	if err := os.MkdirAll(uploadsDir, 0755); err != nil {
-		log.Fatalf("Failed to create uploads directory: %v", err)
-	}
+	// Initialize avatar storage (Azure Blob in prod, local in dev)
+	avatarStorage, uploadsDir := initAvatarStorage(port)
 
 	db, err := sql.Open("postgres", databaseURL)
 	if err != nil {
@@ -88,7 +75,7 @@ func main() {
 	}
 
 	userRepo := repository.NewUserRepository(db)
-	userHandler := handler.NewUserHandler(userRepo, uploadsDir, baseURL)
+	userHandler := handler.NewUserHandler(userRepo, avatarStorage)
 
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/health", healthHandler).Methods("GET")
@@ -100,11 +87,12 @@ func main() {
 	r.HandleFunc("/users/{id}", userHandler.UpdateProfile).Methods("PUT")
 	r.HandleFunc("/users/{id}/avatar", userHandler.UpdateAvatar).Methods("PATCH")
 
-	// Sert les fichiers statiques du dossier uploads (avatars) sous /uploads/.
-	// http.StripPrefix retire le préfixe de l'URL avant de chercher le fichier sur disque.
-	r.PathPrefix("/uploads/").Handler(
-		http.StripPrefix("/uploads/", http.FileServer(http.Dir(uploadsDir))),
-	)
+	// Serve static files only in local storage mode
+	if uploadsDir != "" {
+		r.PathPrefix("/uploads/").Handler(
+			http.StripPrefix("/uploads/", http.FileServer(http.Dir(uploadsDir))),
+		)
+	}
 
 	srv := &http.Server{
 		Addr:         ":" + port,
@@ -149,4 +137,37 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 func readyHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+}
+
+// initAvatarStorage picks Azure Blob Storage if env vars are set, otherwise local.
+// Returns the storage backend and the uploads directory (empty string if Azure).
+func initAvatarStorage(port string) (storage.AvatarStorage, string) {
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME")
+	accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	containerName := os.Getenv("AZURE_STORAGE_CONTAINER_NAME")
+
+	if accountName != "" && accountKey != "" && containerName != "" {
+		azureStorage, err := storage.NewAzureBlobStorage(accountName, accountKey, containerName)
+		if err != nil {
+			log.Fatalf("Failed to initialize Azure Blob Storage: %v", err)
+		}
+		log.Printf("Storage: Azure Blob Storage (account: %s, container: %s)", accountName, containerName)
+		return azureStorage, ""
+	}
+
+	uploadsDir := os.Getenv("UPLOADS_DIR")
+	if uploadsDir == "" {
+		uploadsDir = "./uploads"
+	}
+	baseURL := os.Getenv("BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:" + port
+	}
+
+	if err := os.MkdirAll(uploadsDir, 0755); err != nil {
+		log.Fatalf("Failed to create uploads directory: %v", err)
+	}
+
+	log.Printf("Storage: local (dir: %s, base URL: %s)", uploadsDir, baseURL)
+	return storage.NewLocalStorage(uploadsDir, baseURL), uploadsDir
 }

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,11 @@ require (
 )
 
 require github.com/golang-migrate/migrate/v4 v4.19.1
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 // indirect
+	golang.org/x/net v0.47.0 // indirect
+	golang.org/x/text v0.31.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 h1:JXg2dwJUmPB9JmtVmdEB16APJ7jurfbY5jnfXpJoRMc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0/go.mod h1:YD5h/ldMsG0XiIw7PdyNhLxaM317eFh5yNLccNfGdyw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4/go.mod h1:8mwH4klAm9DUgR2EEHyEEAQlRDvLPyg5fQry3y+cDew=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
@@ -51,6 +57,7 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
@@ -61,7 +68,11 @@ go.opentelemetry.io/otel/metric v1.37.0 h1:mvwbQS5m0tbmqML4NqK+e3aDiO02vsf/Wgbsd
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
+golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
+golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
+golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -5,14 +5,13 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/retich-corp/user/internal/model"
 	"github.com/retich-corp/user/internal/repository"
+	"github.com/retich-corp/user/internal/storage"
 )
 
 var usernameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]{3,30}$`)
@@ -54,18 +53,14 @@ type listUsersResponse struct {
 }
 
 // UserHandler regroupe tous les handlers HTTP liés aux utilisateurs.
-// uploadsDir : chemin du dossier où sont stockés les avatars sur disque.
-// baseURL    : URL publique de base pour construire les liens vers les avatars.
 type UserHandler struct {
-	repo       userRepository
-	uploadsDir string
-	baseURL    string
+	repo    userRepository
+	storage storage.AvatarStorage
 }
 
 // NewUserHandler crée un UserHandler avec les dépendances nécessaires.
-// *repository.UserRepository satisfait userRepository implicitement (duck typing Go).
-func NewUserHandler(repo userRepository, uploadsDir, baseURL string) *UserHandler {
-	return &UserHandler{repo: repo, uploadsDir: uploadsDir, baseURL: baseURL}
+func NewUserHandler(repo userRepository, avatarStorage storage.AvatarStorage) *UserHandler {
+	return &UserHandler{repo: repo, storage: avatarStorage}
 }
 
 // writeJSON factorise l'écriture d'une réponse JSON pour éviter la répétition
@@ -128,19 +123,16 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // UpdateAvatar gère PATCH /users/{id}/avatar.
 // Attend un formulaire multipart avec un champ "avatar" contenant le fichier image.
-// Le fichier est sauvegardé sous {uploadsDir}/{id}.{ext}, écrasant l'ancien avatar.
-// Répond 200 + profil complet mis à jour, ou 400 / 404 / 500 selon le cas.
+// Utilise AvatarStorage pour sauvegarder (local en dev, Azure Blob en prod).
 func (h *UserHandler) UpdateAvatar(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 
-	// Limite le body à maxUploadSize pour rejeter les gros fichiers avant même de les lire.
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "file too large (max 5MB)"})
 		return
 	}
 
-	// Récupère le fichier depuis le champ "avatar" du formulaire multipart.
 	file, _, err := r.FormFile("avatar")
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "field 'avatar' is required"})
@@ -148,9 +140,7 @@ func (h *UserHandler) UpdateAvatar(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	// Détecte le type MIME réel depuis les premiers octets du fichier.
-	// On ne fait pas confiance au Content-Type envoyé par le client : n'importe qui
-	// pourrait envoyer un exécutable en prétendant que c'est une image.
+	// Detect MIME type from file content (not client header)
 	buf := make([]byte, 512)
 	n, err := file.Read(buf)
 	if err != nil {
@@ -164,31 +154,18 @@ func (h *UserHandler) UpdateAvatar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remet le curseur au début du fichier pour pouvoir le lire en intégralité ensuite.
 	if _, err = file.Seek(0, io.SeekStart); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 		return
 	}
 
-	// Nomme le fichier avec l'ID utilisateur : {id}.{ext}.
-	// Cela garantit qu'un second upload remplace automatiquement l'ancien avatar
-	// sans laisser de fichiers orphelins sur le disque.
-	filename := id + ext
-	dst, err := os.Create(filepath.Join(h.uploadsDir, filename))
+	// Upload via storage backend (local or Azure)
+	avatarURL, err := h.storage.Upload(r.Context(), id, ext, file)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 		return
 	}
-	defer dst.Close()
 
-	// Copie le fichier depuis la mémoire vers le disque.
-	if _, err = io.Copy(dst, file); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
-		return
-	}
-
-	// Construit l'URL publique de l'avatar et met à jour la base de données.
-	avatarURL := h.baseURL + "/uploads/" + filename
 	profile, err := h.repo.UpdateAvatarURL(id, avatarURL)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {

--- a/internal/handler/user_handler_test.go
+++ b/internal/handler/user_handler_test.go
@@ -14,7 +14,14 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/retich-corp/user/internal/model"
 	"github.com/retich-corp/user/internal/repository"
+	"github.com/retich-corp/user/internal/storage"
 )
+
+// testStorage creates a local storage for tests.
+func testStorage(t *testing.T) storage.AvatarStorage {
+	t.Helper()
+	return storage.NewLocalStorage(t.TempDir(), "http://localhost:8083")
+}
 
 // mockRepo implémente userRepository pour les tests sans base de données.
 type mockRepo struct {
@@ -138,7 +145,7 @@ func pngBytes() []byte {
 // =============================================================================
 
 func TestCreateUser_201_NewUser(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"id":"new-uuid","email":"new@example.com"}`
@@ -170,7 +177,7 @@ func TestCreateUser_200_ExistingUser(t *testing.T) {
 		CreatedAt:           time.Now(),
 		UpdatedAt:           time.Now(),
 	}
-	h := NewUserHandler(&mockRepo{user: existing}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{user: existing}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"id":"new-uuid","email":"existing@example.com"}`
@@ -195,7 +202,7 @@ func TestCreateUser_200_ExistingUser(t *testing.T) {
 }
 
 func TestCreateUser_400_MissingID(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"email":"test@example.com"}`
@@ -210,7 +217,7 @@ func TestCreateUser_400_MissingID(t *testing.T) {
 }
 
 func TestCreateUser_400_MissingEmail(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"id":"some-uuid"}`
@@ -225,7 +232,7 @@ func TestCreateUser_400_MissingEmail(t *testing.T) {
 }
 
 func TestCreateUser_400_InvalidJSON(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("POST", "/users", strings.NewReader("not json"))
@@ -239,7 +246,7 @@ func TestCreateUser_400_InvalidJSON(t *testing.T) {
 }
 
 func TestCreateUser_500_DBError(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"id":"new-uuid","email":"new@example.com"}`
@@ -258,7 +265,7 @@ func TestCreateUser_500_DBError(t *testing.T) {
 // =============================================================================
 
 func TestGetProfile_200(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/test-id", nil)
@@ -278,7 +285,7 @@ func TestGetProfile_200(t *testing.T) {
 }
 
 func TestGetProfile_404(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: repository.ErrNotFound}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: repository.ErrNotFound}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/unknown", nil)
@@ -291,7 +298,7 @@ func TestGetProfile_404(t *testing.T) {
 }
 
 func TestGetProfile_500(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/test-id", nil)
@@ -308,7 +315,7 @@ func TestGetProfile_500(t *testing.T) {
 // =============================================================================
 
 func TestUpdateProfile_200(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"username":"alice","status":"online"}`
@@ -323,7 +330,7 @@ func TestUpdateProfile_200(t *testing.T) {
 }
 
 func TestUpdateProfile_400_InvalidJSON(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("PUT", "/users/test-id", strings.NewReader("not json"))
@@ -337,7 +344,7 @@ func TestUpdateProfile_400_InvalidJSON(t *testing.T) {
 }
 
 func TestUpdateProfile_400_MissingUsername(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"username":"","status":"online"}`
@@ -352,7 +359,7 @@ func TestUpdateProfile_400_MissingUsername(t *testing.T) {
 }
 
 func TestUpdateProfile_500(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"username":"alice","status":"online"}`
@@ -367,7 +374,7 @@ func TestUpdateProfile_500(t *testing.T) {
 }
 
 func TestUpdateProfile_404(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: repository.ErrNotFound}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: repository.ErrNotFound}, testStorage(t))
 	r := newTestRouter(h)
 
 	body := `{"username":"alice","status":"online"}`
@@ -386,7 +393,7 @@ func TestUpdateProfile_404(t *testing.T) {
 // =============================================================================
 
 func TestUpdateAvatar_200(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := newAvatarRequest(t, "test-id", pngBytes(), "avatar")
@@ -399,7 +406,7 @@ func TestUpdateAvatar_200(t *testing.T) {
 }
 
 func TestUpdateAvatar_400_MissingField(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	// Le champ s'appelle "file" au lieu de "avatar".
@@ -413,7 +420,7 @@ func TestUpdateAvatar_400_MissingField(t *testing.T) {
 }
 
 func TestUpdateAvatar_400_InvalidMIME(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := newAvatarRequest(t, "test-id", []byte("this is plain text"), "avatar")
@@ -426,7 +433,7 @@ func TestUpdateAvatar_400_InvalidMIME(t *testing.T) {
 }
 
 func TestUpdateAvatar_404(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: repository.ErrNotFound}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: repository.ErrNotFound}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := newAvatarRequest(t, "unknown", pngBytes(), "avatar")
@@ -439,7 +446,7 @@ func TestUpdateAvatar_404(t *testing.T) {
 }
 
 func TestUpdateAvatar_500(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := newAvatarRequest(t, "test-id", pngBytes(), "avatar")
@@ -456,7 +463,7 @@ func TestUpdateAvatar_500(t *testing.T) {
 // =============================================================================
 
 func TestListUsers_200(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users", nil)
@@ -485,7 +492,7 @@ func TestListUsers_200(t *testing.T) {
 }
 
 func TestListUsers_WithSearch_200(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users?search=alice&sort=-username&limit=10&offset=5", nil)
@@ -511,7 +518,7 @@ func TestListUsers_WithSearch_200(t *testing.T) {
 }
 
 func TestListUsers_Empty_200(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users", nil)
@@ -534,7 +541,7 @@ func TestListUsers_Empty_200(t *testing.T) {
 }
 
 func TestListUsers_LimitCap_200(t *testing.T) {
-	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{profile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users?limit=200", nil)
@@ -554,7 +561,7 @@ func TestListUsers_LimitCap_200(t *testing.T) {
 }
 
 func TestListUsers_InvalidLimit_400(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users?limit=abc", nil)
@@ -567,7 +574,7 @@ func TestListUsers_InvalidLimit_400(t *testing.T) {
 }
 
 func TestListUsers_NegativeOffset_400(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users?offset=-1", nil)
@@ -580,7 +587,7 @@ func TestListUsers_NegativeOffset_400(t *testing.T) {
 }
 
 func TestListUsers_500(t *testing.T) {
-	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{err: errors.New("db error")}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users", nil)
@@ -597,7 +604,7 @@ func TestListUsers_500(t *testing.T) {
 // =============================================================================
 
 func TestCheckUsername_Available(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/check-username?username=new_user", nil)
@@ -617,7 +624,7 @@ func TestCheckUsername_Available(t *testing.T) {
 }
 
 func TestCheckUsername_Taken(t *testing.T) {
-	h := NewUserHandler(&mockRepo{usernameProfile: sampleProfile()}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{usernameProfile: sampleProfile()}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/check-username?username=alice", nil)
@@ -637,7 +644,7 @@ func TestCheckUsername_Taken(t *testing.T) {
 }
 
 func TestCheckUsername_MissingParam(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/check-username", nil)
@@ -650,7 +657,7 @@ func TestCheckUsername_MissingParam(t *testing.T) {
 }
 
 func TestCheckUsername_InvalidFormat(t *testing.T) {
-	h := NewUserHandler(&mockRepo{}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/check-username?username=ab", nil)
@@ -663,7 +670,7 @@ func TestCheckUsername_InvalidFormat(t *testing.T) {
 }
 
 func TestCheckUsername_500(t *testing.T) {
-	h := NewUserHandler(&mockRepo{usernameErr: errors.New("db error")}, t.TempDir(), "http://localhost:8083")
+	h := NewUserHandler(&mockRepo{usernameErr: errors.New("db error")}, testStorage(t))
 	r := newTestRouter(h)
 
 	req := httptest.NewRequest("GET", "/users/check-username?username=some_user", nil)

--- a/internal/storage/azure.go
+++ b/internal/storage/azure.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+)
+
+// AzureBlobStorage stores avatars in Azure Blob Storage.
+type AzureBlobStorage struct {
+	client        *azblob.Client
+	containerName string
+	accountName   string
+}
+
+func NewAzureBlobStorage(accountName, accountKey, containerName string) (*AzureBlobStorage, error) {
+	if accountName == "" {
+		return nil, errors.New("Azure storage account name is required")
+	}
+	if accountKey == "" {
+		return nil, errors.New("Azure storage account key is required")
+	}
+	if containerName == "" {
+		return nil, errors.New("Azure storage container name is required")
+	}
+
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure credentials: %w", err)
+	}
+
+	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
+	client, err := azblob.NewClientWithSharedKeyCredential(serviceURL, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure Blob client: %w", err)
+	}
+
+	return &AzureBlobStorage{
+		client:        client,
+		containerName: containerName,
+		accountName:   accountName,
+	}, nil
+}
+
+func (s *AzureBlobStorage) Upload(ctx context.Context, userID, ext string, content io.Reader) (string, error) {
+	blobName := userID + ext
+
+	_, err := s.client.UploadStream(ctx, s.containerName, blobName, content, nil)
+	if err != nil {
+		return "", fmt.Errorf("upload blob %q to Azure: %w", blobName, err)
+	}
+
+	blobURL := fmt.Sprintf(
+		"https://%s.blob.core.windows.net/%s/%s",
+		s.accountName,
+		s.containerName,
+		blobName,
+	)
+	return blobURL, nil
+}
+
+func (s *AzureBlobStorage) Delete(ctx context.Context, blobName string) error {
+	_, err := s.client.DeleteBlob(ctx, s.containerName, blobName, nil)
+	if err != nil {
+		return fmt.Errorf("delete blob %q on Azure: %w", blobName, err)
+	}
+	return nil
+}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// LocalStorage stores avatars on the local filesystem.
+type LocalStorage struct {
+	uploadsDir string
+	baseURL    string
+}
+
+func NewLocalStorage(uploadsDir, baseURL string) *LocalStorage {
+	return &LocalStorage{uploadsDir: uploadsDir, baseURL: baseURL}
+}
+
+func (s *LocalStorage) Upload(_ context.Context, userID, ext string, content io.Reader) (string, error) {
+	filename := userID + ext
+	dstPath := filepath.Join(s.uploadsDir, filename)
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return "", fmt.Errorf("create avatar file: %w", err)
+	}
+	defer dst.Close()
+
+	if _, err = io.Copy(dst, content); err != nil {
+		return "", fmt.Errorf("write avatar file: %w", err)
+	}
+
+	return s.baseURL + "/uploads/" + filename, nil
+}
+
+func (s *LocalStorage) Delete(_ context.Context, blobName string) error {
+	dstPath := filepath.Join(s.uploadsDir, blobName)
+	err := os.Remove(dstPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete avatar file: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"context"
+	"io"
+)
+
+// AvatarStorage defines the interface for storing user avatar images.
+// Implementations include local filesystem (dev) and Azure Blob Storage (prod).
+type AvatarStorage interface {
+	// Upload saves the avatar file and returns the public URL.
+	// userID is used as the blob/file name prefix.
+	// ext is the file extension (e.g. ".png", ".jpg").
+	Upload(ctx context.Context, userID, ext string, content io.Reader) (string, error)
+
+	// Delete removes the avatar from storage.
+	// blobName is the full filename (e.g. "user-id.png").
+	Delete(ctx context.Context, blobName string) error
+}


### PR DESCRIPTION
…ackends

Replace direct filesystem writes with an AvatarStorage abstraction. Auto-detects Azure Blob Storage when AZURE_STORAGE_* env vars are set, falls back to local filesystem for development. Handler now uses storage.Upload() instead of manual file operations.